### PR TITLE
Preleases in CI and small pre-commit changes 

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - name: "Repo checkout"
@@ -33,6 +34,7 @@ jobs:
         uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
 
       - name: "Install tox"
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     rev: 1.15.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black>=23.3.0]
+        additional_dependencies: [black>=23.7.0]
 
   # Flake8 for linting, line-length adjusted to match Black default
   - repo: https://github.com/PyCQA/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,6 @@ repos:
       - id: check-docstring-first
       - id: debug-statements
       - id: mixed-line-ending
-        args:
-          - "--fix=lf"
 
   # Adds a standard feel to import segments, adds future annotations
   - repo: https://github.com/asottile/reorder-python-imports


### PR DESCRIPTION
2b3caa8 Allow python pre-release to run in CI
71e9960 bump black version for blacken-docs
2ff4917 allow line endings to be auto detected