### PR TITLE
Stop nox clean session from breaking venvs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,17 +17,17 @@ REQUIREMENT_IN_FILES = [
 
 # What we allowed to clean (delete)
 CLEANABLE_TARGETS = [
-    "./**/dist",
-    "./**/build",
-    "./**/.nox",
+    "./dist",
+    "./build",
+    "./.nox",
+    "./.coverage",
+    "./.coverage.*",
+    "./coverage.json",
     "./**/.mypy_cache",
     "./**/.pytest_cache",
-    "./**/.coverage",
     "./**/__pycache__",
     "./**/*.pyc",
     "./**/*.pyo",
-    "./**/coverage.json",
-    "./**/.coverage.*",
 ]
 
 


### PR DESCRIPTION
How about we don't delete the build folder inside the venv?

resolves #151