### PR TITLE
Remove final workflow step

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -105,12 +105,3 @@ jobs:
       - name: "Enforce strict type annotations with mypy"
         run: |
           nox --session mypy_check
-
-  ci-success:
-    name: "CI steps all completed successfully"
-    needs: ["coverage-compile", "mypy-check"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Success"
-        run: |
-          echo "If you are seeing this, the CI run was successful."


### PR DESCRIPTION
This didn't work as I expected it would in GitHub Actions. If a `needs` workflow fails the final workflow is skipped. Skipped workflows, however, do not prevent a PR from being merged.

Instead, just require the mypy and coverage workflows.