### PR TITLE
Refactoring noxfile for testing

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   run-tests-and-coverage:
-    name: "Run nox for tests and coverage"
+    name: "Run pytest with coverage."
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
@@ -40,14 +40,15 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
+          cache: "pip"
 
       - name: "Install nox"
         run: |
-          python -m pip install --upgrade pip nox
+          python -m pip install --upgrade nox
 
       - name: "Run tests and coverage via nox"
         run: |
-          nox --session version_coverage-${{ matrix.python-version }}
+          nox --session test -- partial-coverage
 
       - name: "Save coverage artifact"
         uses: "actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b"
@@ -58,7 +59,7 @@ jobs:
           include-hidden-files: true
 
   coverage-compile:
-    name: "coverage compile"
+    name: "Compile coverage reports."
     needs: "run-tests-and-coverage"
     runs-on: "ubuntu-latest"
     steps:
@@ -69,10 +70,11 @@ jobs:
         uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b"
         with:
           python-version: "3.12"
+          cache: "pip"
 
       - name: "Install nox"
         run: |
-          python -m pip install --upgrade pip nox
+          python -m pip install --upgrade nox
 
       - name: "Download coverage artifacts"
         uses: "actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
-          cache: "pip"
 
       - name: "Install nox"
         run: |
@@ -70,7 +69,6 @@ jobs:
         uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b"
         with:
           python-version: "3.12"
-          cache: "pip"
 
       - name: "Install nox"
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,6 @@ TESTS_PATH = "tests"
 COVERAGE_FAIL_UNDER = 50
 DEFAULT_PYTHON = "3.12"
 PYTHON_MATRIX = ["3.9", "3.10", "3.11", "3.12", "3.13"]
-VENV_BACKEND = "venv"
 VENV_PATH = ".venv"
 REQUIREMENTS_PATH = "./requirements"
 
@@ -32,8 +31,8 @@ CLEANABLE_TARGETS = [
     "./**/*.pyo",
 ]
 
-
 # Define the default sessions run when `nox` is called on the CLI
+nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.sessions = [
     "version_coverage",
     "coverage_combine",
@@ -73,7 +72,7 @@ def dev(session: nox.Session) -> None:
         session.log(f"\n\nRun '{activate_command}' to enter the virtual environment.\n")
 
 
-@nox.session(python=PYTHON_MATRIX, venv_backend=VENV_BACKEND)
+@nox.session(python=PYTHON_MATRIX)
 def version_coverage(session: nox.Session) -> None:
     """Run unit tests with coverage saved to partial file."""
     print_standard_logs(session)
@@ -84,7 +83,7 @@ def version_coverage(session: nox.Session) -> None:
     session.run("coverage", "run", "-p", "-m", "pytest", TESTS_PATH)
 
 
-@nox.session(python=DEFAULT_PYTHON, venv_backend=VENV_BACKEND)
+@nox.session(python=DEFAULT_PYTHON)
 def coverage_combine(session: nox.Session) -> None:
     """Combine all coverage partial files and generate JSON report."""
     print_standard_logs(session)
@@ -99,7 +98,7 @@ def coverage_combine(session: nox.Session) -> None:
     session.run("python", "-m", "coverage", "json")
 
 
-@nox.session(python=DEFAULT_PYTHON, venv_backend=VENV_BACKEND)
+@nox.session(python=DEFAULT_PYTHON)
 def mypy(session: nox.Session) -> None:
     """Run mypy against package and all required dependencies."""
     print_standard_logs(session)
@@ -110,7 +109,7 @@ def mypy(session: nox.Session) -> None:
     session.run("mypy", "-p", MODULE_NAME, "--no-incremental")
 
 
-@nox.session(python=False, venv_backend=VENV_BACKEND)
+@nox.session(python=False)
 def coverage(session: nox.Session) -> None:
     """Generate a coverage report. Does not use a venv."""
     session.run("coverage", "erase")
@@ -118,7 +117,7 @@ def coverage(session: nox.Session) -> None:
     session.run("coverage", "report", "-m")
 
 
-@nox.session(python=DEFAULT_PYTHON, venv_backend=VENV_BACKEND)
+@nox.session(python=DEFAULT_PYTHON)
 def build(session: nox.Session) -> None:
     """Build distribution files."""
     print_standard_logs(session)
@@ -127,7 +126,7 @@ def build(session: nox.Session) -> None:
     session.run("python", "-m", "build")
 
 
-@nox.session(python=DEFAULT_PYTHON, venv_backend=VENV_BACKEND, name="update-deps")
+@nox.session(python=DEFAULT_PYTHON, name="update-deps")
 def update_deps(session: nox.Session) -> None:
     """Process requirement*.txt files, updating only additions/removals."""
     print_standard_logs(session)
@@ -145,7 +144,7 @@ def update_deps(session: nox.Session) -> None:
     )
 
 
-@nox.session(python=DEFAULT_PYTHON, venv_backend=VENV_BACKEND, name="upgrade-deps")
+@nox.session(python=DEFAULT_PYTHON, name="upgrade-deps")
 def upgrade_deps(session: nox.Session) -> None:
     """Process requirement*.txt files and upgrade all libraries as possible."""
     print_standard_logs(session)
@@ -164,7 +163,7 @@ def upgrade_deps(session: nox.Session) -> None:
     )
 
 
-@nox.session(python=False, venv_backend=VENV_BACKEND)
+@nox.session(python=False)
 def clean(_: nox.Session) -> None:
     """Clean cache, .pyc, .pyo, and test/build artifact files from project."""
     count = 0


### PR DESCRIPTION
These changes lean harder into the workflow being centered around the `noxfile.py` and using `nox` for all tasks.

Tests no longer run on a matrix of pythons, removing the need to maintain that matrix in the `noxfile.py`. Locally, tests will run on the python version where nox is installed. CLI options can still override this behavior. Passing `-- partial-coverage` to `nox --session test` will produce a parallel-mode file with no report. `nox --session coverage_combine` is still used to process these though the expectation is that this is a CI action now.

### Add
- nox session `test` for running pytest and generating a coverage report to console

### Update
- CI adjustments to use the new `test` session

### Removed
- nox session `version_coverage`
