### PR TITLE
Create lint session for nox

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -87,8 +87,8 @@ jobs:
           echo "TOTAL=$TOTAL" >> $GITHUB_ENV
           echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
 
-  mypy-check:
-    name: "mypy strict enforcement"
+  linting:
+    name: "Check linting and formatting requirements"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Repo checkout"
@@ -101,8 +101,8 @@ jobs:
 
       - name: "Install nox"
         run: |
-          python -m pip install --upgrade pip nox
+          python -m pip install --upgrade nox
 
-      - name: "Enforce strict type annotations with mypy"
+      - name: "Run formatters and linters"
         run: |
-          nox --session mypy
+          nox --session lint

--- a/noxfile.py
+++ b/noxfile.py
@@ -114,6 +114,7 @@ def run_linters_and_formatters(session: nox.Session) -> None:
     # Handle anything tool that applies corrections first.
     python(
         "isort",
+        "--verbose",
         "--force-single-line-imports",
         "--profile",
         "black",

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,8 @@ MODULE_NAME = "module_name"
 TESTS_PATH = "tests"
 COVERAGE_FAIL_UNDER = 50
 DEFAULT_PYTHON = "3.12"
-VENV_PATH = ".venv"
+VENV_PATH = "./.venv"
+LINT_PATH = "./src"
 REQUIREMENTS_PATH = "./requirements"
 
 # What we allowed to clean (delete)
@@ -33,10 +34,7 @@ CLEANABLE_TARGETS = [
 
 # Define the default sessions run when `nox` is called on the CLI
 nox.options.default_venv_backend = "virtualenv"
-nox.options.sessions = [
-    "test",
-    "mypy",
-]
+nox.options.sessions = ["lint", "test"]
 
 
 @nox.session(python=False)
@@ -104,15 +102,30 @@ def coverage_combine(session: nox.Session) -> None:
     coverage("json")
 
 
-@nox.session(python=DEFAULT_PYTHON)
-def mypy(session: nox.Session) -> None:
-    """Run mypy against package and all required dependencies."""
+@nox.session(name="lint")
+def run_linters_and_formatters(session: nox.Session) -> None:
+    """Run code formatters, linters, and type checking against all files."""
     print_standard_logs(session)
 
-    session.install(".")
-    session.install("-r", "requirements/requirements.txt")
-    session.install("-r", "requirements/requirements-dev.txt")
-    session.run("mypy", "-p", MODULE_NAME, "--no-incremental")
+    session.install(".", "-r", f"{REQUIREMENTS_PATH}/requirements-dev.txt")
+
+    python = partial(session.run, "python", "-m")
+
+    # Handle anything tool that applies corrections first.
+    python(
+        "isort",
+        "--force-single-line-imports",
+        "--profile",
+        "black",
+        "--add-import",
+        "from __future__ import annotations",
+        LINT_PATH,
+    )
+    python("black", "--verbose", LINT_PATH)
+
+    # Linters: aka, things that yell but want you to fix things
+    python("flake8", "--show-source", "--verbose", LINT_PATH)
+    python("mypy", "--no-incremental", "--package", MODULE_NAME)
 
 
 @nox.session(python=DEFAULT_PYTHON)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,6 @@ homepage = "https://github.com/[ORG NAME]/[REPO NAME]"
 [tool.setuptools_scm]
 # Purposely left empty
 
-[tool.black]
-line-length = 100
-target-version = ['py39']
-
 [tool.setuptools.package-data]
 "module_name" = ["py.typed"]
 


### PR DESCRIPTION
Move black, flake8, and isort actions into the `noxfile.py` alongside
the existing mypy session. This will give the dev control over when
these checks are run, allowing pre-commit to be optional in the local
environment.

### Add
- `nox -s lint` session to run formatters, linters, and type checking

### Update
- CI to use new `lint` session in nox

### Remove
- `mypy` nox session
- `black` configuration section from `pyproject.toml`