### PR TITLE
Remove flake8 and mypy hooks from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,19 +30,3 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-
-  # Flake8 for linting, line-length adjusted to match Black default
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.2
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-builtins
-          - flake8-pep585
-          - pep8-naming
-
-  # Type enforcement for Python
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
-    hooks:
-      - id: mypy


### PR DESCRIPTION
These hooks cannot fix themselves which defeats the power of pre-commit both locally and in the ci. Both `flake8` and `mypy` checks are now handled by nox. They are available locally with `nox -s lint` and run in the CI as a requirable job.