### PR TITLE
A case study...

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,9 @@ def run_tests_with_coverage(session: nox.Session) -> None:
     """Run pytest with coverage, outputs console report and json."""
     print_standard_logs(session)
 
-    session.install(".", "-r", f"{REQUIREMENTS_PATH}/requirements-test.txt")
+    session.install(".")
+    session.install("-r", f"{REQUIREMENTS_PATH}/requirements.txt")
+    session.install("-r", f"{REQUIREMENTS_PATH}/requirements-test.txt")
 
     coverage = partial(session.run, "python", "-m", "coverage")
 
@@ -103,7 +105,9 @@ def run_linters_and_formatters(session: nox.Session) -> None:
     """Run code formatters, linters, and type checking against all files."""
     print_standard_logs(session)
 
-    session.install(".", "-r", f"{REQUIREMENTS_PATH}/requirements-dev.txt")
+    session.install(".")
+    session.install("-r", f"{REQUIREMENTS_PATH}/requirements.txt")
+    session.install("-r", f"{REQUIREMENTS_PATH}/requirements-dev.txt")
 
     python = partial(session.run, "python", "-m")
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -12,3 +12,4 @@ isort
 
 # type checking
 mypy
+types-requests

--- a/src/module_name/sample.py
+++ b/src/module_name/sample.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import requests
+
 
 def main() -> bool:
     """Main"""
@@ -17,3 +19,8 @@ def squared(value: int) -> int:
 def isodd(value: int) -> bool:
     """Return if value is odd."""
     return bool(value % 2)
+
+
+def health_check() -> bool:
+    """Returns true when github.com is accessible."""
+    return requests.get("https://github.com").ok

--- a/tests/sample_test.py
+++ b/tests/sample_test.py
@@ -7,7 +7,7 @@ import pytest
 from module_name import sample
 
 
-def test_main():
+def test_main() -> None:
     """Main test"""
     assert sample.main()
 
@@ -20,5 +20,9 @@ def test_main():
         (16, 256),
     ),
 )
-def test_squared(value_in, expected):
+def test_squared(value_in: int, expected: int) -> None:
     assert sample.squared(value_in) == expected
+
+
+def test_health_check() -> None:
+    assert sample.health_check()


### PR DESCRIPTION
What happens when you assume and don't test what you build?

Did you answer, what you build doesn't work as expected? Good, you're better than me.

During the refactor the noxfile, I dropped the requirements being dynamically handled in the `pyproject.toml`. Not seeing the trap I built for myself, I proceeded to build the noxfile with the impression that everything was working. Behold, folly. Not once did I notice I never installed the `requirements.txt` in the nox sessions. Something that is rather required if tests or linting is to pass.

I even had taken a step toward avoiding the trap. I added `requests` to the dependency list "just to see it work". And then, like a silly-goose, I never actually used requests so my testing failed to produce the error that was inevitable.

This has been my egg talk.