### PR TITLE
Remove pre-commit from nox dev session

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# For use with pre-commit.ci - No expectation of use locally
 ci:
   autoupdate_schedule: monthly
 
@@ -6,27 +7,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"
     hooks:
-      - id: check-json
-      - id: check-toml
-      - id: check-yaml
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: check-docstring-first
-
-  # Adds a standard feel to import segments
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-        args:
-          - "--force-single-line-imports"
-          - "--add-import"
-          - "from __future__ import annotations"
-          - "--profile"
-          - "black"
-
-  # Format code. No, I don't like everything black does either.
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black
+      - id: mixed-line-ending

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,3 @@ nox -s update-deps
 ```bash
 nox -s upgrade-deps
 ```
-
----
-
-## [pre-commit](https://pre-commit.com)
-
-> A framework for managing and maintaining multi-language pre-commit hooks.
-
-This repo is setup with a `.pre-commit-config.yaml` with the expectation that
-any code submitted for review already passes all selected pre-commit checks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Python 3.9 | 3.10 | 3.11 | 3.12 | 3.13](https://img.shields.io/badge/Python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/Preocts/python-src-template/main.svg)](https://results.pre-commit.ci/latest/github/Preocts/python-src-template/main)
 [![Python tests](https://github.com/Preocts/python-src-template/actions/workflows/python-tests.yml/badge.svg?branch=main)](https://github.com/Preocts/python-src-template/actions/workflows/python-tests.yml)

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,9 +76,6 @@ def dev(session: nox.Session) -> None:
 
     python("pip", "install", "--editable", ".[dev,test]", *contraint, external=True)
 
-    python("pip", "install", "pre-commit", external=True)
-    session.run(f"{venv_path}/pre-commit", "install", external=True)
-
     if not os.environ.get("VIRTUAL_ENV"):
         session.log(f"\n\nRun '{activate_command}' to enter the virtual environment.\n")
 


### PR DESCRIPTION
The `.pre-commit-config.yaml` will continue to hold helpful, self-correcting checks for use in pre-commit.ci. The expectation of running pre-commit locally is being removed.