### PR TITLE
Guard against uv.lock drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,9 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: mixed-line-ending
+
+  # Ensure the uv.lock file has been updated
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.8.7
+    hooks:
+      - id: uv-lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ pre-commit.
 uvx nox -s dev
 ```
 
+### Validate uv.lock
+
+```console
+uvx nox -s lock
+```
+
 ### Run tests and display coverage
 
 ```console
@@ -68,7 +74,7 @@ uvx nox -s test
 Passing extra arguements to pytest:
 
 ```console
-uvx nos -s test -- -vvv -x --full-trace
+uvx nox -s test -- -vvv -x --full-trace
 ```
 
 ### Run linters

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ CLEANABLE_TARGETS = [
 
 # Define the default sessions run when `nox` is called on the CLI
 nox.options.default_venv_backend = "uv"
-nox.options.sessions = ["format", "lint", "test"]
+nox.options.sessions = ["lock", "format", "lint", "test"]
 
 # All linters and formatters are run with `uv run --active`
 LINTERS: list[tuple[str, ...]] = [
@@ -121,6 +121,12 @@ def run_formatters(session: nox.Session) -> None:
 def build_artifacts(session: nox.Session) -> None:
     """Build a sdist and wheel."""
     session.run("uv", "build")
+
+
+@nox.session(name="lock", python=False)
+def validate_lock_file(session: nox.Session) -> None:
+    """Ensure the uv.lock file exists and is aligned with dependencies."""
+    session.run("uv", "lock")
 
 
 @nox.session(name="upgrade", python=False)


### PR DESCRIPTION
Add a pre-commit hook to ensure the lockfile has been updated with any dependency changes. Likewise, create a nox session to do the same.

This combination will help ensure the uv.lock file is correct even when pushed before updating. pre-commit-ci can auto-fix this.