### PR TITLE
Clean up gha python setup

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,9 +13,6 @@ on:
     branches:
       - "main"
 
-env:
-  UV_PYTHON_PREFERENCE: "only-system"
-
 jobs:
   run-tests-and-coverage:
     name: "Run nox for tests and coverage"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,20 +18,8 @@ env:
   UV_PYTHON_PREFERENCE: "only-system"
 
 jobs:
-  settings:
-    runs-on: "ubuntu-latest"
-    name: "Define workflow settings"
-    steps:
-      - name: "Repo checkout"
-        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
-
-      - name: "Define settings"
-        run: |
-          echo "python_version=$(<.python-version)" >> $GITHUB_OUTPUT
-
   run-tests-and-coverage:
     name: "Run nox for tests and coverage"
-    needs: "settings"
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
@@ -54,14 +42,12 @@ jobs:
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
         with:
-          python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
 
       - name: "Install the latest version of uv"
         uses: "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"
         with:
           version: "latest"
-          python-version: "${{ matrix.python-version }}"
           enable-cache: true
 
       - name: "Run tests and coverage via nox"
@@ -77,7 +63,7 @@ jobs:
 
   coverage-compile:
     name: "coverage compile"
-    needs: ["settings", "run-tests-and-coverage"]
+    needs: "run-tests-and-coverage"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Repo checkout"
@@ -85,14 +71,11 @@ jobs:
 
       - name: "Set up Python"
         uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
-        with:
-          python-version: ${{ steps.settings.outputs.python_version }}
 
       - name: "Install the latest version of uv"
         uses: "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"
         with:
           version: "latest"
-          python-version: ${{ steps.settings.outputs.python_version }}
           enable-cache: true
 
       - name: "Download coverage artifacts"
@@ -117,7 +100,6 @@ jobs:
 
   linters-and-formatters:
     name: "linters and formatters"
-    needs: "settings"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Repo checkout"
@@ -125,14 +107,11 @@ jobs:
 
       - name: "Set up Python"
         uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
-        with:
-          python-version: ${{ steps.settings.outputs.python_version }}
 
       - name: "Install the latest version of uv"
         uses: "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"
         with:
           version: "latest"
-          python-version: ${{ steps.settings.outputs.python_version }}
           enable-cache: true
 
       - name: "Run linters and formatters"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,7 +43,7 @@ jobs:
           enable-cache: true
 
       - name: "Run tests and coverage via nox"
-        run: "uvx nox --session test -- partial-coverage no-config"
+        run: "uvx nox --session test -- partial-coverage"
 
       - name: "Save coverage artifact"
         uses: "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,6 +48,7 @@ jobs:
         uses: "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"
         with:
           version: "latest"
+          python-version: "${{ matrix.python-version }}"
           enable-cache: true
 
       - name: "Run tests and coverage via nox"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,5 @@
 name: "python tests and coverage"
 # Uses:
-# https://github.com/actions/setup-python : v5.6.0 a26af69be951a213d495a4c3e4e4022e16d87065
 # https://github.com/actions/checkout : v4.2.2 11bd71901bbe5b1630ceea73d27597364c9af683
 # https://github.com/actions/download-artifact : v5.0.0 634f93cb2916e3fdff6788551b99b062d0335ce0
 # https://github.com/actions/upload-artifact : v4.6.2 ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -39,11 +38,6 @@ jobs:
       - name: "Repo checkout"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
 
-      - name: "Set up Python ${{ matrix.python-version }}"
-        uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
-        with:
-          allow-prereleases: true
-
       - name: "Install the latest version of uv"
         uses: "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"
         with:
@@ -69,9 +63,6 @@ jobs:
     steps:
       - name: "Repo checkout"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
-
-      - name: "Set up Python"
-        uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
 
       - name: "Install the latest version of uv"
         uses: "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"
@@ -105,9 +96,6 @@ jobs:
     steps:
       - name: "Repo checkout"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
-
-      - name: "Set up Python"
-        uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
 
       - name: "Install the latest version of uv"
         uses: "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,9 +66,6 @@ def run_tests_with_coverage(session: nox.Session) -> None:
     """Run pytest in isolated environment, display coverage. Extra arguements passed to pytest."""
     partial = "partial-coverage" in session.posargs
     extra: list[str] = []
-    if "no-config" in session.posargs:
-        session.posargs.remove("no-config")
-        extra = ["--no-config"]
 
     session.run_install("uv", "sync", *SYNC_ARGS, *extra)
 


### PR DESCRIPTION
`setup-python` actions are no longer needed with the `setup-uv` action in place. Ensure the matrix run of tests passes the python-version to `setup-uv` correctly. This also allows the removal of the `no-config` optional argument for `nox --session test`.

The `settings` job is entirely removed.